### PR TITLE
Restrict recipe search to authenticated users

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -2,6 +2,7 @@ import { Geist, Geist_Mono } from 'next/font/google';
 import Nav from '@/components/Nav';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import { AuthProvider } from '@/context/AuthContext';
 import './globals.css';
 
 const geistSans = Geist({
@@ -23,13 +24,15 @@ export default function RootLayout({ children }) {
     return (
         <html lang='en'>
             <body className='antialiased' >
-                <Header />
+                <AuthProvider>
+                    <Header />
 
-                <main id="main-content"
-                    className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-16">
-                    {children}
-                </main>
-                <Footer />
+                    <main id="main-content"
+                        className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-16">
+                        {children}
+                    </main>
+                    <Footer />
+                </AuthProvider>
             </body>
         </html>
     );

--- a/src/app/login/page.jsx
+++ b/src/app/login/page.jsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState, useContext, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { AuthContext } from '@/context/AuthContext';
+
+export default function LoginPage() {
+  const { login, isAuthenticated, error, loading } = useContext(AuthContext);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const router = useRouter();
+
+  useEffect(() => {
+    if (isAuthenticated) router.push('/');
+  }, [isAuthenticated, router]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await login(email, password);
+  };
+
+  return (
+    <div className="max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-4 text-amber-800">Login</h1>
+      {error && <p className="text-red-500 mb-4">{error}</p>}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block mb-1">Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full border px-3 py-2 rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full border px-3 py-2 rounded"
+            required
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={loading}
+          className="px-4 py-2 bg-amber-100 text-amber-800 font-bold rounded-lg shadow hover:bg-amber-200 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-amber-400"
+        >
+          {loading ? 'Loading...' : 'Login'}
+        </button>
+      </form>
+      <p className="mt-4 text-sm">
+        Need an account?{' '}
+        <Link href="/register" className="text-amber-600 underline">
+          Register
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import Link from 'next/link';
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import { HeartIcon, BookmarkSquareIcon, DevicePhoneMobileIcon } from '@heroicons/react/24/solid';
@@ -10,11 +10,13 @@ const greatVibes = Great_Vibes({ subsets: ['latin'], weight: '400' });
 
 import SearchModal from '@/components/SearchModal';
 import FeaturedRecipes from '@/components/FeaturedRecipes';
+import { AuthContext } from '@/context/AuthContext';
 
 export default function Home() {
     const [showSearchBar, setShowSearchBar] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
     const [modalOpen, setModalOpen] = useState(false);
+    const { isAuthenticated } = useContext(AuthContext);
 
     return (
         <>
@@ -33,42 +35,54 @@ export default function Home() {
 
             {/* Search Modal */}
             <section className="py-2">
-                <div className="flex flex-col sm:flex-row gap-4 justify-center mt-8">
-                    <button
-                        onClick={() => setShowSearchBar(v => !v)}
-                        className="flex items-center px-4 py-2 bg-amber-100 text-amber-800 font-bold rounded-lg shadow hover:bg-amber-200 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-amber-400 transition-colors group"
-                    >
-                        <MagnifyingGlassIcon className="h-5 w-5 mr-2 group-hover:animate-[wiggle_0.3s_ease-in-out]" />
-                        Search
-                    </button>
-                </div>
-                {showSearchBar && (
-                    <form
-                        onSubmit={e => {
-                            e.preventDefault();
-                            setModalOpen(true);
-                        }}
-                        className="mt-4 flex gap-2 justify-center"
-                    >
-                        <input
-                            value={searchQuery}
-                            onChange={e => setSearchQuery(e.target.value)}
-                            placeholder="Search recipes..."
-                            className="px-4 py-2 border border-gray-300 rounded-lg w-full max-w-md text-amber-800 bg-white shadow focus:outline-none focus:ring-2 focus:ring-amber-400"
+                {isAuthenticated ? (
+                    <>
+                        <div className="flex flex-col sm:flex-row gap-4 justify-center mt-8">
+                            <button
+                                onClick={() => setShowSearchBar(v => !v)}
+                                className="flex items-center px-4 py-2 bg-amber-100 text-amber-800 font-bold rounded-lg shadow hover:bg-amber-200 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-amber-400 transition-colors group"
+                            >
+                                <MagnifyingGlassIcon className="h-5 w-5 mr-2 group-hover:animate-[wiggle_0.3s_ease-in-out]" />
+                                Search
+                            </button>
+                        </div>
+                        {showSearchBar && (
+                            <form
+                                onSubmit={e => {
+                                    e.preventDefault();
+                                    setModalOpen(true);
+                                }}
+                                className="mt-4 flex gap-2 justify-center"
+                            >
+                                <input
+                                    value={searchQuery}
+                                    onChange={e => setSearchQuery(e.target.value)}
+                                    placeholder="Search recipes..."
+                                    className="px-4 py-2 border border-gray-300 rounded-lg w-full max-w-md text-amber-800 bg-white shadow focus:outline-none focus:ring-2 focus:ring-amber-400"
+                                />
+                                <button
+                                    type="submit"
+                                    className="px-4 py-2 bg-amber-100 text-amber-800 font-bold rounded-lg shadow hover:bg-amber-200 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-amber-400 transition-colors"
+                                >
+                                    Go
+                                </button>
+                            </form>
+                        )}
+                        <SearchModal
+                            open={modalOpen}
+                            onClose={() => setModalOpen(false)}
+                            query={searchQuery}
                         />
-                        <button
-                            type="submit"
-                            className="px-4 py-2 bg-amber-100 text-amber-800 font-bold rounded-lg shadow hover:bg-amber-200 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-amber-400 transition-colors"
-                        >
-                            Go
-                        </button>
-                    </form>
+                    </>
+                ) : (
+                    <div className="text-center mt-8">
+                        <p className="text-amber-800">Please sign in to search for recipes.</p>
+                        <p className="mt-2">
+                            <Link href="/login" className="text-amber-600 underline">Login</Link> or{' '}
+                            <Link href="/register" className="text-amber-600 underline">Register</Link>
+                        </p>
+                    </div>
                 )}
-                <SearchModal
-                    open={modalOpen}
-                    onClose={() => setModalOpen(false)}
-                    query={searchQuery}
-                />
             </section>
 
             {/* Featured Recipe  Modal */}

--- a/src/app/register/page.jsx
+++ b/src/app/register/page.jsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useState, useContext, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { AuthContext } from '@/context/AuthContext';
+
+export default function RegisterPage() {
+  const { register, isAuthenticated, error, loading } = useContext(AuthContext);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const router = useRouter();
+
+  useEffect(() => {
+    if (isAuthenticated) router.push('/');
+  }, [isAuthenticated, router]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await register(name, email, password);
+  };
+
+  return (
+    <div className="max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-4 text-amber-800">Register</h1>
+      {error && <p className="text-red-500 mb-4">{error}</p>}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block mb-1">Name</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full border px-3 py-2 rounded"
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full border px-3 py-2 rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full border px-3 py-2 rounded"
+            required
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={loading}
+          className="px-4 py-2 bg-amber-100 text-amber-800 font-bold rounded-lg shadow hover:bg-amber-200 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-amber-400"
+        >
+          {loading ? 'Loading...' : 'Register'}
+        </button>
+      </form>
+      <p className="mt-4 text-sm">
+        Already have an account?{' '}
+        <Link href="/login" className="text-amber-600 underline">
+          Login
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -1,18 +1,20 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import Link from 'next/link';
-// TODO import { useContext } from 'react';
-// TODO import { AuthContext } from '@/context/AuthContext';
-
-const navItems = [
-    { href: '/', label: 'Home' },
-    { href: '/login', label: 'Login' },
-    { href: '/register', label: 'Register' },
-];
+import { AuthContext } from '@/context/AuthContext';
 
 export default function Nav() {
     const [openMenu, setOpenMenu] = useState(false);
+    const { isAuthenticated, logout } = useContext(AuthContext);
+
+    const navItems = [
+        { href: '/', label: 'Home' },
+        ...(!isAuthenticated ? [
+            { href: '/login', label: 'Login' },
+            { href: '/register', label: 'Register' }
+        ] : [])
+    ];
 
     return (
         <nav className="relative top-0 w-full z-50">
@@ -26,6 +28,13 @@ export default function Nav() {
                         </Link>
                     </li>
                 ))}
+                {isAuthenticated && (
+                    <li>
+                        <button onClick={logout} className="text-amber-800 hover:text-amber-600">
+                            Logout
+                        </button>
+                    </li>
+                )}
             </ul>
             {/* Mobile Menu Toggle */}
             <button
@@ -61,12 +70,25 @@ export default function Nav() {
                             <Link
                                 href={href}
                                 className="block text-amber-800 hover:text-amber-600"
-                                onClick={() => setOpen(false)}
+                                onClick={() => setOpenMenu(false)}
                             >
                                 {label}
                             </Link>
                         </li>
                     ))}
+                    {isAuthenticated && (
+                        <li>
+                            <button
+                                onClick={() => {
+                                    logout();
+                                    setOpenMenu(false);
+                                }}
+                                className="block text-amber-800 hover:text-amber-600"
+                            >
+                                Logout
+                            </button>
+                        </li>
+                    )}
                 </ul>
             )}
         </nav>

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -1,5 +1,7 @@
+'use client';
+
 import React, { createContext, useState, useEffect } from 'react';
-import * as jwtDecode from 'jwt-decode';
+import jwtDecode from 'jwt-decode';
 
 export const AuthContext = createContext();
 
@@ -75,6 +77,32 @@ export const AuthProvider = ({ children }) => {
         }
     };
 
+    const register = async (name, email, password) => {
+        setLoading(true);
+        try {
+            const res = await fetch('/api/register', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name, email, password })
+            });
+            if (!res.ok) {
+                const data = await res.json();
+                throw new Error(data.message || 'Registration failed');
+            }
+            const { token: jwt, user: userData } = await res.json();
+            localStorage.setItem('token', jwt);
+            setToken(jwt);
+            setUser(userData);
+            setError(null);
+        } catch (err) {
+            setError(err.message);
+            setUser(null);
+            setToken(null);
+        } finally {
+            setLoading(false);
+        }
+    };
+
     const logout = () => {
         localStorage.removeItem('token');
         setToken(null);
@@ -91,6 +119,7 @@ export const AuthProvider = ({ children }) => {
                 loading,
                 error,
                 login,
+                register,
                 logout
             }}>
             {children}


### PR DESCRIPTION
## Summary
- Add client-side auth context with login and registration helpers
- Wrap application with auth provider and conditionally render nav items and search UI based on sign-in state
- Introduce dedicated login and registration pages for users

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894c5ad159083229ad54a39edda3187